### PR TITLE
Fixed scrollbar issue

### DIFF
--- a/src/ProjectPage/ProjectApp.tsx
+++ b/src/ProjectPage/ProjectApp.tsx
@@ -3,14 +3,25 @@ import ProjectsContainer from "./ProjectsContainer";
 import 'bootstrap/dist/css/bootstrap.min.css';
 import '../scripts,styles/projects.css';
 import '../scripts,styles/index.css';
-import React from "react";
+import React, { useEffect } from "react";
 
-function ProjectApp(){
-    return(
-        <div>
-            <ProjectsContainer/>
-        </div>
+
+function ProjectApp() {
+    useEffect(() => {
+      // Add the overflow style to the body when the component is mounted
+      document.body.style.overflow = "hidden";
+  
+      // Remove the overflow style from the body when the component is unmounted
+      return () => {
+        document.body.style.overflow = "";
+      };
+    }, []);
+  
+    return (
+      <div>
+        <ProjectsContainer />
+      </div>
     );
-}
+  }
 
 export default ProjectApp;

--- a/src/scripts,styles/projects.css
+++ b/src/scripts,styles/projects.css
@@ -34,12 +34,6 @@
 .container::-webkit-scrollbar-thumb {
   background-color: transparent;
 }
-/**/
-
-/*Remove scrollbar on the entire html page */
-body{
-  overflow: hidden;
-}
 
 .scroll-container::-webkit-scrollbar {
   width: 0.5em;


### PR DESCRIPTION
Fixed scrollbar not being ann option onn homepagge:

Turns out project.css is applied globally, causing all pages to have no scrollbar, due to this property on projects.css:

body {
  overflow: hidden;
}

Converted above property into a useEffect hook, that appllies property only when ProjectApp is mounted, annd removes property when unmounted